### PR TITLE
Fix error when accessing newly created manuscript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
-/.flatpak-builder
+.flatpak/flatpak-builder
 /.var
 
 /builddir
 token.txt
+_build
 
 /subprojects/blueprint-compiler
 /subprojects/libpanel-1
 notes.md
+
+.vscode
 
 repo/

--- a/scriptorium/models/project.py
+++ b/scriptorium/models/project.py
@@ -215,9 +215,10 @@ class Project(GObject.Object):
 
         # Find the YAML data block
         resource_data = None
-        for data in yaml_data["resources"]:
-            if data["identifier"] == identifier:
-                resource_data = data
+        if yaml_data:
+            for data in yaml_data["resources"]:
+                if data["identifier"] == identifier:
+                    resource_data = data
         if resource_data is None:
             logger.error(f"Could not find {identifier} in the YAML file")
             return None

--- a/scriptorium/views/editor_scenes.py
+++ b/scriptorium/views/editor_scenes.py
@@ -57,12 +57,12 @@ class ScrptWritingPanel(Adw.NavigationPage):
         )
 
         # Open a test scene for debugging
-        self.connect("map", self.on_map)
+        # self.connect("map", self.on_map)
 
     def on_map(self, _widget):
         test_scene_id = "9ede0795-6ee2-486d-8b94-4c95cef254c1"
         writer = Writer(self.editor.project.get_resource(test_scene_id))
-        #writer.load_scene(self.editor.project.get_resource(test_scene_id))
+        # writer.load_scene(self.editor.project.get_resource(test_scene_id))
         writer.present(self)
 
     @Gtk.Template.Callback()


### PR DESCRIPTION
Added a yaml_data validation to ensure there is data to be traversed. The fix led to another error, but the error came from a debug test performed on editor_scenes.py, commenting out the test line resolved the issue.